### PR TITLE
Added an option for a custom page routeValue key

### DIFF
--- a/src/MvcPaging.Demo/Controllers/PagingController.cs
+++ b/src/MvcPaging.Demo/Controllers/PagingController.cs
@@ -40,6 +40,12 @@ namespace MvcPaging.Demo.Controllers
 			return View(this.allProducts.ToPagedList(currentPageIndex, DefaultPageSize));
 		}
 
+        public ActionResult CustomPageRouteValueKey(SearchModel search)
+        {
+            int currentPageIndex = search.page.HasValue ? search.page.Value - 1 : 0;
+            return View(this.allProducts.ToPagedList(currentPageIndex, DefaultPageSize));
+        }
+
 		public ActionResult ViewByCategory(string categoryName, int? page)
 		{
 			categoryName = categoryName ?? this.categories[0];

--- a/src/MvcPaging.Demo/Models/SearchModel.cs
+++ b/src/MvcPaging.Demo/Models/SearchModel.cs
@@ -1,0 +1,12 @@
+﻿namespace MvcPaging.Demo.Models
+{
+    public class SearchModel
+    {
+        public int? page { get; set; }
+
+        public SearchModel()
+        {
+            page = 1;
+        }
+    }
+}

--- a/src/MvcPaging.Demo/MvcPaging.Demo.csproj
+++ b/src/MvcPaging.Demo/MvcPaging.Demo.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Models\SearchModel.cs" />
     <Compile Include="Models\Product.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -93,6 +94,7 @@
     <Content Include="Scripts\jquery.unobtrusive-ajax.min.js" />
     <Content Include="Areas\Area51\Views\_ViewStart.cshtml" />
     <Content Include="Views\Paging\Bootstrap.cshtml" />
+    <Content Include="Views\Paging\CustomPageRouteValueKey.cshtml" />
     <None Include="Views\Paging\Index.cshtml" />
     <None Include="Views\Paging\IndexAjax.cshtml" />
     <None Include="Views\Paging\ProductsByCategory.cshtml" />

--- a/src/MvcPaging.Demo/Views/Home/Index.cshtml
+++ b/src/MvcPaging.Demo/Views/Home/Index.cshtml
@@ -34,3 +34,7 @@
 	<dt>@Html.ActionLink("Alternative pager DisplayTemplate", "Bootstrap", "Paging")</dt>
 	<dd>The pager in combination with Twitter Bootstrap</dd>
 </dl>
+<dl>
+	<dt>@Html.ActionLink("Paging with a custom page route value key", "CustomPageRouteValueKey", "Paging")</dt>
+	<dd>The pager supports specifying the route value key used for 'page' when generating pagination links</dd>
+</dl>

--- a/src/MvcPaging.Demo/Views/Paging/CustomPageRouteValueKey.cshtml
+++ b/src/MvcPaging.Demo/Views/Paging/CustomPageRouteValueKey.cshtml
@@ -1,0 +1,25 @@
+﻿@model IPagedList<MvcPaging.Demo.Models.Product>
+@{
+	ViewBag.Title = "Browse all products";
+}
+<h2>@ViewBag.Title</h2>
+<table class="grid">
+	<thead>
+		<tr>
+			<th>Product name</th>
+			<th>Category</th>
+		</tr>
+	</thead>
+	<tbody>
+		@foreach (var product in Model) { 
+			<tr>
+				<td>@product.Name</td>
+				<td>@product.Category</td>
+			</tr>
+		}
+	</tbody>
+</table>
+<div class="pager">
+	@Html.Pager(Model.PageSize, Model.PageNumber, Model.TotalItemCount).Options(o => o
+                .PageRouteValueKey("Search.page"))
+</div>

--- a/src/MvcPaging/Pager.cs
+++ b/src/MvcPaging/Pager.cs
@@ -168,14 +168,14 @@ namespace MvcPaging
 			if (pageNumber == 1 && ! this.pagerOptions.AlwaysAddFirstPageNumber)
 			{
 				pageLinkValueDictionary = new RouteValueDictionary(this.pagerOptions.RouteValues);
-				if (routeDataValues.ContainsKey("page"))
+				if (routeDataValues.ContainsKey(this.pagerOptions.PageRouteValueKey))
 				{
-					routeDataValues.Remove("page");
+					routeDataValues.Remove(this.pagerOptions.PageRouteValueKey);
 				}
 			}
 			else
 			{
-				pageLinkValueDictionary = new RouteValueDictionary(this.pagerOptions.RouteValues) { { "page", pageNumber } };
+				pageLinkValueDictionary = new RouteValueDictionary(this.pagerOptions.RouteValues) { { this.pagerOptions.PageRouteValueKey, pageNumber } };
 			}
 
 			// To be sure we get the right route, ensure the controller and action are specified.

--- a/src/MvcPaging/PagerOptions.cs
+++ b/src/MvcPaging/PagerOptions.cs
@@ -6,17 +6,20 @@ namespace MvcPaging
 	public class PagerOptions
 	{
 		const int DefaultMaxNrOfPages = 10;
+        const string DefaultPageRouteValueKey = "page";
 
 		public RouteValueDictionary RouteValues { get; internal set; }
 		public string DisplayTemplate { get; internal set; }
 		public int MaxNrOfPages { get; internal set; }
 		public AjaxOptions AjaxOptions { get; internal set; }
-		public bool AlwaysAddFirstPageNumber { get; internal set; } 
+		public bool AlwaysAddFirstPageNumber { get; internal set; }
+		public string PageRouteValueKey { get; set; }
 
 		public PagerOptions()
 		{
 			this.RouteValues = new RouteValueDictionary();
 			MaxNrOfPages = DefaultMaxNrOfPages;
+            PageRouteValueKey = DefaultPageRouteValueKey;
 		}
 	}
 }

--- a/src/MvcPaging/PagerOptionsBuilder.cs
+++ b/src/MvcPaging/PagerOptionsBuilder.cs
@@ -116,5 +116,20 @@ namespace MvcPaging
 			this.pagerOptions.AjaxOptions = ajaxOptions;
 			return this;
 		}
+
+        /// <summary>
+        /// Set the page routeValue key for pagination links
+        /// </summary>
+        /// <param name="pageRouteValueKey"></param>
+        /// <returns></returns>
+        public PagerOptionsBuilder PageRouteValueKey(string pageRouteValueKey)
+        {
+            if (pageRouteValueKey == null)
+            {
+                throw new ArgumentException("pageRouteValueKey may not be null", "pageRouteValueKey");
+            }
+            this.pagerOptions.PageRouteValueKey = pageRouteValueKey;
+            return this;
+        }
 	}
 }


### PR DESCRIPTION
Relates to issue #13

The key defaults to 'page' as it was before. Now you can pass in the value of the page routeValue key into the options.

I've also added an example of this to the demo.
