### PR TITLE
Added Ajax Support for Bootstrap Pagination Display Template

### DIFF
--- a/src/MvcPaging.Demo/Views/Shared/DisplayTemplates/BootstrapPagination.cshtml
+++ b/src/MvcPaging.Demo/Views/Shared/DisplayTemplates/BootstrapPagination.cshtml
@@ -29,6 +29,17 @@
 	{
 		aBuilder.MergeAttribute("href", link.Url);
 	}
+	
+	// Ajax support
+	if (Model.AjaxOptions != null)
+        {
+            foreach (var ajaxOption in Model.AjaxOptions.ToUnobtrusiveHtmlAttributes())
+            {
+                aBuilder.MergeAttribute(ajaxOption.Key, ajaxOption.Value.ToString(), true);
+            }
+        }
+	
+	
 	if (link.DisplayText == "«")
 	{
 		aBuilder.SetInnerText("←");


### PR DESCRIPTION
Hey Martijn,

I'm using your MVC Paging package (great work btw) with Bootstrap & Ajax. I figured out that Ajax support was missing with the BootstrapPagination Display Template of your Demo Project, so I just added it.

If you like it, feel free to update your Demo Project with that.

Cheers,

Thierry
