### PR TITLE
Added support in PagerOptions for custom displaytext on next/previous links

### DIFF
--- a/src/MvcPaging/Pager.cs
+++ b/src/MvcPaging/Pager.cs
@@ -15,7 +15,7 @@ namespace MvcPaging
 		private readonly int totalItemCount;
 		protected readonly PagerOptions pagerOptions;
 
-		public Pager(HtmlHelper htmlHelper, int pageSize, int currentPage, int totalItemCount)
+        public Pager(HtmlHelper htmlHelper, int pageSize, int currentPage, int totalItemCount)
 		{
 			this.htmlHelper = htmlHelper;
 			this.pageSize = pageSize;
@@ -35,8 +35,9 @@ namespace MvcPaging
 			var pageCount = (int)Math.Ceiling(totalItemCount / (double)pageSize);
 			var model = new PaginationModel { PageSize = this.pageSize, CurrentPage = this.currentPage, TotalItemCount = this.totalItemCount, PageCount = pageCount };
 
-			// Previous
-			model.PaginationLinks.Add(currentPage > 1 ? new PaginationLink { Active = true, DisplayText = "«", PageIndex = currentPage - 1, Url = generateUrl(currentPage - 1) } : new PaginationLink { Active = false, DisplayText = "«" });
+            var prevousPageText = this.pagerOptions.PreviousPageText;
+            // Previous
+            model.PaginationLinks.Add(currentPage > 1 ? new PaginationLink { Active = true, DisplayText = prevousPageText, PageIndex = currentPage - 1, Url = generateUrl(currentPage - 1) } : new PaginationLink { Active = false, DisplayText = prevousPageText });
 
 			var start = 1;
 			var end = pageCount;
@@ -101,8 +102,9 @@ namespace MvcPaging
 				model.PaginationLinks.Add(new PaginationLink { Active = true, PageIndex = pageCount, DisplayText = pageCount.ToString(), Url = generateUrl(pageCount) });
 			}
 
-			// Next
-			model.PaginationLinks.Add(currentPage < pageCount ? new PaginationLink { Active = true, PageIndex = currentPage + 1, DisplayText = "»", Url = generateUrl(currentPage + 1) } : new PaginationLink { Active = false, DisplayText = "»" });
+            var nextPageText = this.pagerOptions.NextPageText;
+            // Next
+            model.PaginationLinks.Add(currentPage < pageCount ? new PaginationLink { Active = true, PageIndex = currentPage + 1, DisplayText = nextPageText, Url = generateUrl(currentPage + 1) } : new PaginationLink { Active = false, DisplayText = nextPageText });
 
 			// AjaxOptions
 			if (pagerOptions.AjaxOptions != null)

--- a/src/MvcPaging/PagerOptions.cs
+++ b/src/MvcPaging/PagerOptions.cs
@@ -11,6 +11,8 @@ namespace MvcPaging
 			public const string DisplayTemplate = null;
 			public const bool AlwaysAddFirstPageNumber = false;
 			public const string DefaultPageRouteValueKey = "page";
+            public const string PreviousPageText = "«";
+            public const string NextPageText = "»";
 		}
 
 		/// <summary>
@@ -23,6 +25,8 @@ namespace MvcPaging
 			public static string DisplayTemplate = DefaultDefaults.DisplayTemplate;
 			public static bool AlwaysAddFirstPageNumber = DefaultDefaults.AlwaysAddFirstPageNumber;
 			public static string DefaultPageRouteValueKey = DefaultDefaults.DefaultPageRouteValueKey;
+            public static string PreviousPageText = DefaultDefaults.PreviousPageText;
+            public static string NextPageText = DefaultDefaults.NextPageText;
 
 			public static void Reset()
 			{
@@ -30,6 +34,8 @@ namespace MvcPaging
 				DisplayTemplate = DefaultDefaults.DisplayTemplate;
 				AlwaysAddFirstPageNumber = DefaultDefaults.AlwaysAddFirstPageNumber;
 				DefaultPageRouteValueKey = DefaultDefaults.DefaultPageRouteValueKey;
+                PreviousPageText = DefaultDefaults.PreviousPageText;
+                NextPageText = DefaultDefaults.NextPageText;
 			}
 		}
 
@@ -40,6 +46,8 @@ namespace MvcPaging
 		public bool AlwaysAddFirstPageNumber { get; internal set; }
 		public string Action { get; internal set; }
 		public string PageRouteValueKey { get; set; }
+		public string PreviousPageText { get; set; }
+		public string NextPageText { get; set; }
 
 		public PagerOptions()
 		{
@@ -48,6 +56,8 @@ namespace MvcPaging
 			MaxNrOfPages = Defaults.MaxNrOfPages;
 			AlwaysAddFirstPageNumber = Defaults.AlwaysAddFirstPageNumber;
 			PageRouteValueKey = Defaults.DefaultPageRouteValueKey;
+            PreviousPageText = DefaultDefaults.PreviousPageText;
+            NextPageText = DefaultDefaults.NextPageText;
 		}
 	}
 }

--- a/src/MvcPaging/PagerOptionsBuilder.cs
+++ b/src/MvcPaging/PagerOptionsBuilder.cs
@@ -50,6 +50,28 @@ namespace MvcPaging
 		}
 
 		/// <summary>
+		/// Set the text for previous page navigation.
+		/// </summary>
+        /// <param name="previousPageText"></param>
+		/// <returns></returns>
+		public PagerOptionsBuilder SetPreviousPageText(string previousPageText)
+		{
+		    pagerOptions.PreviousPageText = previousPageText;
+			return this;
+		}
+
+		/// <summary>
+        /// Set the text for next page navigation.
+		/// </summary>
+        /// <param name="nextPageText"></param>
+		/// <returns></returns>
+		public PagerOptionsBuilder SetNextPageText(string nextPageText)
+		{
+		    pagerOptions.NextPageText = nextPageText;
+			return this;
+		}
+
+		/// <summary>
 		/// Set custom route value parameters for the pager links.
 		/// </summary>
 		/// <param name="routeValues"></param>


### PR DESCRIPTION
Added support in PagerOptions for custom displaytext on next/previous links.

Instead of "«" and "»" you might want the words "Next" and "Previous".
Example of usage:

```
@Html.Pager(Model.PageSize, Model.PageNumber, Model.TotalItemCount).Options(o => o.AddRouteValue("categoryname", ViewBag.CategoryDisplayName)
                                                                   .SetNextPageText("Next")
                                                                   .SetPreviousPageText("Previous"))
```
