### PR TITLE
Last page calculation fix

### DIFF
--- a/src/MvcPaging.Tests/PagerTests.cs
+++ b/src/MvcPaging.Tests/PagerTests.cs
@@ -195,7 +195,6 @@ namespace MvcPaging.Tests
                 new PaginationLink { Active = true, DisplayText = "4", PageIndex = 4, Url = "/test/4" },
                 new PaginationLink { Active = true, DisplayText = "5", PageIndex = 5, Url = "/test/5" },
                 new PaginationLink { Active = false, DisplayText = "...", Url = null, IsSpacer = true },
-                new PaginationLink { Active = true, DisplayText = "16", PageIndex = 16, Url = "/test/16" },
                 new PaginationLink { Active = true, DisplayText = "17", PageIndex = 17, Url = "/test/17" },
                 new PaginationLink { Active = true, DisplayText = "»", PageIndex = 2, Url = "/test/2" }
             };
@@ -373,7 +372,6 @@ namespace MvcPaging.Tests
                 new PaginationLink { Active = true, DisplayText = "4", PageIndex = 4, Url = "/test/4" },
                 new PaginationLink { Active = true, DisplayText = "5", PageIndex = 5, Url = "/test/5" },
                 new PaginationLink { Active = false, DisplayText = "...", Url = null, IsSpacer = true },
-                new PaginationLink { Active = true, DisplayText = "12", PageIndex = 12, Url = "/test/12" },
                 new PaginationLink { Active = true, DisplayText = "13", PageIndex = 13, Url = "/test/13" },
                 new PaginationLink { Active = true, DisplayText = "»", PageIndex = 2, Url = "/test/2" }
             };

--- a/src/MvcPaging/Pager.cs
+++ b/src/MvcPaging/Pager.cs
@@ -115,9 +115,9 @@ namespace MvcPaging
                 {
                     model.PaginationLinks.Add(new PaginationLink { Active = false, DisplayText = "...", IsSpacer = true });
                 }
-                if (pageCount - 2 > end)
+                if (end < pageCount - 2)
                 {
-                    model.PaginationLinks.Add(new PaginationLink { Active = true, PageIndex = pageCount - 1, DisplayText = (pageCount - 1).ToString(), Url = generateUrl(pageCount - 1) });
+                    model.PaginationLinks.Add(new PaginationLink { Active = true, PageIndex = pageCount, DisplayText = (pageCount).ToString(), Url = generateUrl(pageCount) });
                 }
             }
 


### PR DESCRIPTION
This is a fix for strange behaivor that you reproduce with next steps:

    1) Run MvcPaging.Demo
    2) Go to "Paging with a custom page route value key"
    3) Click on last page "52" just after "..."
    4) You'll see that page 53 appears.

Also wrong tests are fixed. They expected to have two pages at the end right after "...", but there should be only one page.