### PR TITLE
Use the customized defaults

### DIFF
--- a/src/MvcPaging.Tests/PagerTests.cs
+++ b/src/MvcPaging.Tests/PagerTests.cs
@@ -52,16 +52,22 @@ namespace MvcPaging.Tests
             PagerOptions.Defaults.AlwaysAddFirstPageNumber = !PagerOptions.DefaultDefaults.AlwaysAddFirstPageNumber;
             PagerOptions.Defaults.DisplayTemplate = PagerOptions.DefaultDefaults.DisplayTemplate + "-test";
             PagerOptions.Defaults.MaxNrOfPages = PagerOptions.DefaultDefaults.MaxNrOfPages + 1;
+            PagerOptions.Defaults.PreviousPageText = "PreviousPrevious";
+            PagerOptions.Defaults.NextPageText = "NextNext";
 
             var second = new PagerOptions();
 
             Assert.AreEqual(second.AlwaysAddFirstPageNumber, PagerOptions.Defaults.AlwaysAddFirstPageNumber);
             Assert.AreEqual(second.DisplayTemplate, PagerOptions.Defaults.DisplayTemplate);
             Assert.AreEqual(second.MaxNrOfPages, PagerOptions.Defaults.MaxNrOfPages);
+            Assert.AreEqual(second.PreviousPageText, "PreviousPrevious");
+            Assert.AreEqual(second.NextPageText, "NextNext");
 
             Assert.AreNotEqual(first.AlwaysAddFirstPageNumber, second.AlwaysAddFirstPageNumber);
             Assert.AreNotEqual(first.DisplayTemplate, second.DisplayTemplate);
             Assert.AreNotEqual(first.MaxNrOfPages, second.MaxNrOfPages);
+            Assert.AreNotEqual(first.PreviousPageText, second.PreviousPageText);
+            Assert.AreNotEqual(first.NextPageText, second.NextPageText);
 
             // cleanup
             PagerOptions.Defaults.Reset();

--- a/src/MvcPaging/PagerOptions.cs
+++ b/src/MvcPaging/PagerOptions.cs
@@ -47,6 +47,7 @@ namespace MvcPaging
             public static bool DisplayFirstPage = DefaultDefaults.DisplayFirstPage;
             public static bool DisplayLastPage = DefaultDefaults.DisplayLastPage;
             public static bool UseItemCountAsPageCount = DefaultDefaults.UseItemCountAsPageCount;
+            public static bool HidePreviousAndNextPage = DefaultDefaults.HidePreviousAndNextPage;
             public static string CustomRouteName = DefaultDefaults.CustomRouteName;
 
             public static void Reset()
@@ -66,6 +67,7 @@ namespace MvcPaging
                 DisplayFirstPage = DefaultDefaults.DisplayFirstPage;
                 DisplayLastPage = DefaultDefaults.DisplayLastPage;
                 UseItemCountAsPageCount = DefaultDefaults.UseItemCountAsPageCount;
+                HidePreviousAndNextPage = DefaultDefaults.HidePreviousAndNextPage;
                 CustomRouteName = DefaultDefaults.CustomRouteName;
             }
         }
@@ -119,19 +121,19 @@ namespace MvcPaging
             MaxNrOfPages = Defaults.MaxNrOfPages;
             AlwaysAddFirstPageNumber = Defaults.AlwaysAddFirstPageNumber;
             PageRouteValueKey = Defaults.DefaultPageRouteValueKey;
-            PreviousPageText = DefaultDefaults.PreviousPageText;
-            PreviousPageTitle = DefaultDefaults.PreviousPageTitle;
-            NextPageText = DefaultDefaults.NextPageText;
-            NextPageTitle = DefaultDefaults.NextPageTitle;
-            FirstPageText = DefaultDefaults.FirstPageText;
-            FirstPageTitle = DefaultDefaults.FirstPageTitle;
-            LastPageText = DefaultDefaults.LastPageText;
-            LastPageTitle = DefaultDefaults.LastPageTitle;
-            DisplayFirstPage = DefaultDefaults.DisplayFirstPage;
-            DisplayLastPage = DefaultDefaults.DisplayLastPage;
-            UseItemCountAsPageCount = DefaultDefaults.UseItemCountAsPageCount;
-            HidePreviousAndNextPage = DefaultDefaults.HidePreviousAndNextPage;
-            CustomRouteName = DefaultDefaults.CustomRouteName;
+            PreviousPageText = Defaults.PreviousPageText;
+            PreviousPageTitle = Defaults.PreviousPageTitle;
+            NextPageText = Defaults.NextPageText;
+            NextPageTitle = Defaults.NextPageTitle;
+            FirstPageText = Defaults.FirstPageText;
+            FirstPageTitle = Defaults.FirstPageTitle;
+            LastPageText = Defaults.LastPageText;
+            LastPageTitle = Defaults.LastPageTitle;
+            DisplayFirstPage = Defaults.DisplayFirstPage;
+            DisplayLastPage = Defaults.DisplayLastPage;
+            UseItemCountAsPageCount = Defaults.UseItemCountAsPageCount;
+            HidePreviousAndNextPage = Defaults.HidePreviousAndNextPage;
+            CustomRouteName = Defaults.CustomRouteName;
         }
     }
 }


### PR DESCRIPTION
Right now, if you set defaults (e.g. `Defaults.NextPageText`), it's *always* being ignored. When you use `new PagerOptions()` it uses `DefaultDefaults.NextPageText`!

This PR fixes this and all other default options so that `new PagerOptions()` uses the customized defaults.